### PR TITLE
Ziptastic move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/austinkregel/ziptastic-php-guzzle.svg?branch=master)](https://travis-ci.org/austinkregel/ziptastic-php-guzzle)
-
 # Ziptastic PHP with Guzzle
 
 This package was brought into existence because of [this package](https://github.com/Ziptastic/ziptastic-php), specifically because of the [first enhancement](https://github.com/Ziptastic/ziptastic-php/issues/1)
@@ -13,7 +11,7 @@ Using Ziptastic requires an API key, you can get one by signing up with Ziptasti
 Ziptastic PHP can be installed via composer:
 
 ````
-composer require kregel/ziptastic
+composer require ziptastic/guzzle
 ````
 
 ## Usage
@@ -26,7 +24,7 @@ The first way to use this is by using `Zipper` which will be using a more "plain
 
 include "vendor/autoload.php";
 
-use Kregel\Ziptastic\Zipper;
+use Ziptastic\Guzzle\Zipper;
 
 $key = 'Your Api Key from ziptastic';
 
@@ -42,7 +40,7 @@ If that isn't your cup of tea or you just want to get things done, you can use `
 
 include "vendor/autoload.php";
 
-use Kregel\Ziptastic\Ziptastic;
+use Ziptastic\Guzzle\Ziptastic;
 
 $key = 'Your Api Key from ziptastic';
 
@@ -60,7 +58,7 @@ The first way to use this is by using `Zipper` which will be using a more "plain
 
 include "vendor/autoload.php";
 
-use Kregel\Ziptastic\Zipper;
+use Ziptastic\Guzzle\Zipper;
 
 $key = 'Your Api Key from ziptastic';
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kregel/ziptastic",
+  "name": "ziptastic/guzzle",
   "description": "Guzzle based PHP SDK for the Ziptastic Lookup API",
   "require": {
     "php": ">=5.4"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "autoload": {
     "psr-4": {
-      "Kregel\\Ziptastic\\": "src/"
+      "Ziptastic\\Guzzle\\": "src/"
     }
   }
 }

--- a/src/Guzzle/ZiptasticRequest.php
+++ b/src/Guzzle/ZiptasticRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kregel\Ziptastic\Guzzle;
+namespace Ziptastic\Guzzle\Guzzle;
 
 use ArrayAccess;
 use Exception;

--- a/src/Zipper.php
+++ b/src/Zipper.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Kregel\Ziptastic;
+namespace Ziptastic\Guzzle;
 
 use Exception;
-use Kregel\Ziptastic\Guzzle\ZiptasticRequest;
+use Ziptastic\Guzzle\Guzzle\ZiptasticRequest;
 
 class Zipper extends ZiptasticRequest
 {

--- a/src/Ziptastic.php
+++ b/src/Ziptastic.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Kregel\Ziptastic;
+namespace Ziptastic\Guzzle;
 
-use Kregel\Ziptastic\Guzzle\ZiptasticRequest;
+use Ziptastic\Guzzle\Guzzle\ZiptasticRequest;
 
 class Ziptastic extends ZiptasticRequest
 {

--- a/tests/ZipperTest.php
+++ b/tests/ZipperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kregel\Ziptastic\Zipper;
+use Ziptastic\Guzzle\Zipper;
 
 class ZipperTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/ZiptasticTest.php
+++ b/tests/ZiptasticTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kregel\Ziptastic\Ziptastic;
+use Ziptastic\Guzzle\Ziptastic;
 
 class ZiptasticTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Moved over all the namespacing and I believe all the instances that referenced `Kregel\Ziptastic` to `Ziptastic\Guzzle`... I think.